### PR TITLE
fix: disable Turbo on authentication forms to fix login issues

### DIFF
--- a/app/views/auth/sessions/new.html.erb
+++ b/app/views/auth/sessions/new.html.erb
@@ -9,7 +9,7 @@
   </p>
 
   <div class="p-6 pt-5 mt-6 bg-white border shadow-sm rounded-xl pb-7 border-neutral-200">
-    <%= labeled_form_with url: auth_login_path, class: "flex flex-col gap-4" do |form| %>
+    <%= labeled_form_with url: auth_login_path, class: "flex flex-col gap-4", data: { turbo: false } do |form| %>
       <%= form.email_field :email,
                        required: true,
                        class: "input w-full",

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -16,7 +16,7 @@
   </p>
 
   <div class="p-6 pt-5 mt-6 bg-white border shadow-sm rounded-xl pb-7 border-neutral-200">
-    <%= labeled_form_with url: password_path(params[:token]), class: "flex flex-col gap-4", method: :put do |form| %>
+    <%= labeled_form_with url: password_path(params[:token]), class: "flex flex-col gap-4", method: :put, data: { turbo: false } do |form| %>
       <%= form.password_field :password,
                           class: "input w-full",
                           required: true,

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -16,7 +16,7 @@
   </p>
 
   <div class="p-6 pt-5 mt-6 bg-white border shadow-sm rounded-xl pb-7 border-neutral-200">
-    <%= labeled_form_with url: passwords_path, class: "flex flex-col gap-4" do |form| %>
+    <%= labeled_form_with url: passwords_path, class: "flex flex-col gap-4", data: { turbo: false } do |form| %>
       <%= form.email_field :email,
                        required: true,
                        class: "input w-full",

--- a/app/views/public/newsletters/partials/_subscribe.html.erb
+++ b/app/views/public/newsletters/partials/_subscribe.html.erb
@@ -1,7 +1,7 @@
 <% autofocus = local_assigns.fetch(:autofocus, false) %>
 
 <div class="p-6 pt-5 pb-7 bg-white rounded-lg shadow-without-inset mb-5">
-  <%= labeled_form_with url: subscribe_path, class: "flex flex-col gap-4" do |form| %>
+  <%= labeled_form_with url: subscribe_path, class: "flex flex-col gap-4", data: { turbo: false } do |form| %>
     <%= form.email_field :email,
                      required: true,
                      class: "input w-full",

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -6,7 +6,7 @@
   </div>
 
   <div class="p-6 pt-5 mt-6 bg-white border shadow-sm rounded-xl pb-7 border-neutral-200">
-    <%= labeled_form_with url: signup_path, local: true, class: "flex flex-col gap-4" do |form| %>
+    <%= labeled_form_with url: signup_path, class: "flex flex-col gap-4", data: { turbo: false } do |form| %>
       <%= form.text_field :name,
                       required: true,
                       class: "input w-full",


### PR DESCRIPTION
Turbo Drive was preventing session cookies from being properly set during login/signup, causing redirects back to the login page. Disabling Turbo on all authentication forms (login, signup, password reset, and subscription) ensures cookies are set correctly via traditional form submissions.